### PR TITLE
Do not deep merge "special" objects by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Use the class constructor to configure the settings for the paginated query.
 #### constructor(Model, { criteria = {}, pagination = {}, sort = {}, projection }, options = {})
 `Model`: The Mongoose model instance to query. _Required._
 
-`criteria`: A query criteria object to apply to the paginated query. Can be any MongoDB query. For example: `{ deleted: false }` or `{ age: { $gt: 30 } }`. Optional.
+`criteria`: A query criteria object to apply to the paginated query. Can be any MongoDB query. For example: `{ deleted: false }` or `{ age: { $gt: 30 } }`. The criteria will be deeply merged, but will ignore "special" objects such as `ObjectId` and, by default, will only merge "plain objects." Optional.
 
 `pagination`: The pagination parameters object. Can accept a `first` and/or `after` property. The `first` value specifies the limit/page size. The `after` value specifies the cursor to start at when paginating. For example: `{ first: 50, after: 'some-cursor-value' }` would return the first 50 edges after the provided cursor. By default the results will be limited to 10 edges. Optional.
 
@@ -27,7 +27,7 @@ Use the class constructor to configure the settings for the paginated query.
 
 `projection`: Specifies the fields to return from the database. For example: `{ field: 1 }` or `{ field: 0 }` would include or exclude the specified field, respectively. If left `undefined`, or as an empty object, all fields will be returned (which is the default behavior). Optional.
 
-`options`: Specifies additional configuration options, such as default limit, max limit, sort collation, and sort created field.
+`options`: Specifies additional configuration options, such as default limit, max limit, sort collation, object merge options, and sort created field.
 
 Complete example:
 ```js
@@ -69,9 +69,9 @@ Use the class constructor to configure the settings for the type-ahead query.
 
 `term`: The search term. Can/should be a partial phrase. _Required._
 
-`criteria`: Additional MongoDB query criteria to apply when querying. For example `{ deleted: false }`. Optional.
+`criteria`: Additional MongoDB query criteria to apply when querying. For example `{ deleted: false }`. The criteria will be deeply merged, but will ignore "special" objects such as `ObjectId` and, by default, will only merge "plain objects." Optional.
 
-`options`: The type-ahead configuration options object. Has three possible properties:
+`options`: The type-ahead configuration options object. Has three type-ahead related properties:
 ```js
 {
   // Determines how the regex is constructed.
@@ -86,6 +86,7 @@ Use the class constructor to configure the settings for the type-ahead query.
   caseSensitive: false,
 }
 ```
+In addition, the `options` will also accept the optional `mergeOptions` object property htat can be used to override the default merge rules.
 
 #### paginate(Model, pagination = {}, options = {})
 Creates a `Pagination` instance using the constructed `TypeAhead` options.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "deepmerge": "^2.1.0",
-    "escape-string-regexp": "^1.0.5"
+    "escape-string-regexp": "^1.0.5",
+    "is-plain-object": "^2.0.4"
   },
   "optionalDependencies": {
     "@limit0/graphql-custom-types": "^1.0.1",

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -1,6 +1,9 @@
 const deepMerge = require('deepmerge');
+const isPlainObject = require('is-plain-object');
 const Sort = require('./sort');
 const Limit = require('./limit');
+
+const mergeOptions = { isMergeableObject: isPlainObject };
 
 class Pagination {
   /**
@@ -18,7 +21,8 @@ class Pagination {
    * @param {string} params.sort.field The sort field name.
    * @param {string} params.sort.order The sort order. Either 1/-1 or asc/desc.
    * @param {?object} params.projection The field projection (fields to return).
-   * @param {object} options Additional sort and limit options. See the corresponding classes.
+   * @param {object} options Additional sort, limit and criteria merge options.
+   *                         See the corresponding classes.
    */
   constructor(Model, {
     criteria = {},
@@ -31,8 +35,12 @@ class Pagination {
     // Set the Model to use for querying.
     this.Model = Model;
 
+    // Sets the options for deep merging criteria object.
+    // If not set, will only merge plain objects, per `is-plain-object`.
+    this.mergeOptions = options.mergeOptions || mergeOptions;
+
     // Set/merge any query criteria.
-    this.criteria = deepMerge({}, criteria);
+    this.criteria = deepMerge({}, criteria, this.mergeOptions);
 
     // Set the limit and after cursor.
     const { first, after } = pagination;
@@ -155,7 +163,7 @@ class Pagination {
     const run = async () => {
       const { field, order } = this.sort;
 
-      const filter = deepMerge({}, this.criteria);
+      const filter = deepMerge({}, this.criteria, this.mergeOptions);
       const limits = {};
       const ors = [];
 

--- a/src/type-ahead.js
+++ b/src/type-ahead.js
@@ -1,9 +1,14 @@
 const escapeRegex = require('escape-string-regexp');
 const deepMerge = require('deepmerge');
+const isPlainObject = require('is-plain-object');
 const Pagination = require('./pagination');
+
+const mergeOptions = { isMergeableObject: isPlainObject };
 
 class TypeAhead {
   constructor(field, term, criteria = {}, options = {}) {
+    this.mergeOptions = options.mergeOptions || mergeOptions;
+
     this.options = options;
     this.values = {};
 
@@ -40,11 +45,11 @@ class TypeAhead {
   }
 
   set criteria(criteria) {
-    this.values.criteria = deepMerge({}, criteria);
+    this.values.criteria = deepMerge({}, criteria, this.mergeOptions);
   }
 
   get criteria() {
-    return deepMerge({}, this.values.criteria);
+    return deepMerge({}, this.values.criteria, this.mergeOptions);
   }
 
   paginate(Model, pagination = {}, options = {}) {

--- a/test/pagination.spec.js
+++ b/test/pagination.spec.js
@@ -1,7 +1,10 @@
 require('./connection');
 const Model = require('./mongoose/model');
+const { Types } = require('mongoose');
 const Pagination = require('../src/pagination');
 const sandbox = sinon.createSandbox();
+
+const { ObjectId } = Types;
 
 const data = [
   { name: 'foo', deleted: false },
@@ -44,6 +47,31 @@ describe('pagination', function() {
   it('should return an object', function(done) {
     expect(new Pagination()).to.be.an('object');
     done();
+  });
+
+  it('should not merge special objects by default.', async function() {
+    const id = ObjectId('5b3980c956d5a405cc4007c5');
+    const criteria = {
+      foo: 'bar',
+      id,
+      bar: { a: 'b' },
+    };
+    const instance = new Pagination(Model, { criteria });
+    expect(instance.criteria).to.deep.equal(criteria);
+    expect(instance.criteria.id).to.be.an.instanceOf(ObjectId);
+  });
+
+  it('should merge special objects when specifically instructured to.', async function() {
+    const mergeOptions = {};
+    const id = ObjectId('5b3980c956d5a405cc4007c5');
+    const criteria = {
+      foo: 'bar',
+      id,
+      bar: { a: 'b' },
+    };
+    const instance = new Pagination(Model, { criteria }, { mergeOptions });
+    expect(instance.criteria.id).to.be.an('object');
+    expect(instance.criteria.id).to.not.be.an.instanceOf(ObjectId);
   });
 
   describe('#getTotalCount', function() {

--- a/test/type-ahead.spec.js
+++ b/test/type-ahead.spec.js
@@ -1,9 +1,37 @@
 require('./connection');
 const TypeAhead = require('../src/type-ahead');
 const Model = require('./mongoose/model');
+const { Types } = require('mongoose');
 const Pagination = require('../src/pagination');
 
+const { ObjectId } = Types;
+
 describe('type-ahead', function() {
+  it('should not merge special objects by default.', async function() {
+    const id = ObjectId('5b3980c956d5a405cc4007c5');
+    const criteria = {
+      foo: 'bar',
+      id,
+      bar: { a: 'b' },
+    };
+    const instance = new TypeAhead('foo', 'bar', criteria);
+    expect(instance.criteria).to.deep.equal(criteria);
+    expect(instance.criteria.id).to.be.an.instanceOf(ObjectId);
+  });
+
+  it('should merge special objects when specifically instructured to.', async function() {
+    const mergeOptions = {};
+    const id = ObjectId('5b3980c956d5a405cc4007c5');
+    const criteria = {
+      foo: 'bar',
+      id,
+      bar: { a: 'b' },
+    };
+    const instance = new TypeAhead('foo', 'bar', criteria, { mergeOptions });
+    expect(instance.criteria.id).to.be.an('object');
+    expect(instance.criteria.id).to.not.be.an.instanceOf(ObjectId);
+  });
+
   describe('.field', function() {
     it('should throw an error when empty', function(done) {
       const message = 'A type ahead field must be specified.';


### PR DESCRIPTION
When `criteria` objects contained "special" objects (such as `ObjectId` instances), these were being improperly merged into plain objects. Now, by default, all non "plain objects" will be left as-is when merging. This can be overridden using the `options.mergeOptions` property, per the rules defined by the `deepmerge` package: https://www.npmjs.com/package/deepmerge#options