### PR TITLE
Resolve issue with dot-notated/embedded fields

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -62,10 +62,7 @@ class Pagination {
    * @return {Promise}
    */
   getTotalCount() {
-    const run = () => this.Model
-      .find(this.criteria)
-      .comment(this.createComment('getTotalCount')).count();
-
+    const run = () => this.Model.count(this.criteria);
     if (!this.promises.count) {
       this.promises.count = run();
     }

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -173,9 +173,9 @@ class Pagination {
           filter._id = { [op]: doc.id };
         } else {
           doc = await this.findCursorModel(this.after, { [field]: 1 });
-          limits[op] = doc[field];
+          limits[op] = doc.get(field);
           ors.push({
-            [field]: doc[field],
+            [field]: doc.get(field),
             _id: { [op]: doc.id },
           });
           filter.$or = [{ [field]: limits }, ...ors];

--- a/test/pagination.spec.js
+++ b/test/pagination.spec.js
@@ -34,6 +34,7 @@ describe('pagination', function() {
   });
 
   beforeEach(function() {
+    sandbox.spy(Model, 'count');
     sandbox.spy(Model, 'find');
     sandbox.spy(Model, 'findOne');
     sandbox.spy(Pagination.prototype, 'getEdges');
@@ -102,7 +103,7 @@ describe('pagination', function() {
       const r1 = await paginated.getTotalCount();
       const r2 = await paginated.getTotalCount();
       expect(r1).to.equal(r2);
-      sinon.assert.calledOnce(Model.find);
+      sinon.assert.calledOnce(Model.count);
     });
   });
 


### PR DESCRIPTION
Will now use the `doc.get()` function when building the criteria. This ensures that fields that are dot-notated/pathed are properly set. For example `attr.foo` will now be set using `doc.get('attr.foo')` instead of `doc['attr.foo']` :)

Also used the native `count` method for total count instead of find. 