### PR TITLE
Create `paginable` Mongoose plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ const Pagination = require('./pagination');
 const ElasticPagination = require('./search-pagination');
 const TypeAhead = require('./type-ahead');
 const paginationResolvers = require('./resolvers');
+const plugins = require('./plugins');
 
 module.exports = {
   Pagination,
   TypeAhead,
   ElasticPagination,
   paginationResolvers,
+  plugins,
 };

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -1,0 +1,5 @@
+const paginablePlugin = require('./paginable');
+
+module.exports = {
+  paginablePlugin,
+};

--- a/src/plugins/paginable.js
+++ b/src/plugins/paginable.js
@@ -1,0 +1,8 @@
+const Pagination = require('../pagination');
+
+module.exports = function paginable(schema) {
+  // eslint-disable-next-line no-param-reassign
+  schema.statics.paginate = function paginate({ criteria, pagination, sort } = {}) {
+    return new Pagination(this, { criteria, pagination, sort });
+  };
+};

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,6 +7,7 @@ describe('index', function() {
       'ElasticPagination',
       'TypeAhead',
       'paginationResolvers',
+      'plugins',
     );
     done();
   });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
+--recursive
 --require ./test/bootstrap.js

--- a/test/mongoose/schema.js
+++ b/test/mongoose/schema.js
@@ -1,4 +1,5 @@
 const { Schema } = require('mongoose');
+const { paginablePlugin } = require('../../src/plugins');
 
 const schema = new Schema({
   name: {
@@ -11,6 +12,8 @@ const schema = new Schema({
 }, {
   timestamps: true,
 });
+
+schema.plugin(paginablePlugin);
 
 schema.index({ name: 1, _id: 1 }, { unique: true });
 schema.index({ name: -1, _id: -1 }, { unique: true });

--- a/test/plugins/paginable.spec.js
+++ b/test/plugins/paginable.spec.js
@@ -1,0 +1,38 @@
+require('../connection');
+const Model = require('../mongoose/model');
+const Pagination = require('../../src/pagination');
+const sandbox = sinon.createSandbox();
+
+describe('plugins/paginable', function() {
+  describe('#paginate', function() {
+
+    it('should return a Pagination instance.', async function() {
+      expect(Model.paginate()).to.be.an.instanceOf(Pagination);
+    });
+
+    it('should pass the appropriate `Model` to the instance.', async function() {
+      const paginated = Model.paginate();
+      expect(paginated.Model.modelName).to.equal(Model.modelName);
+    });
+
+    it('should pass the appropriate `criteria` values to the instance.', async function() {
+      const criteria = { foo: 'bar' };
+      const paginated = Model.paginate({ criteria });
+      expect(paginated.criteria).to.deep.equal(criteria);
+    });
+
+    it('should pass the appropriate `pagination` values to the instance.', async function() {
+      const pagination = { first: 5, after: '1234' };
+      const paginated = Model.paginate({ pagination });
+      expect(paginated.first.value).to.equal(5);
+      expect(paginated.after).to.equal('1234');
+    });
+
+    it('should pass the appropriate `sort` values to the instance.', async function() {
+      const sort = { field: 'name', order: 'asc' };
+      const paginated = Model.paginate({ sort });
+      expect(paginated.sort.field).to.equal('name');
+      expect(paginated.sort.order).to.equal(1);
+    });
+  });
+});


### PR DESCRIPTION
Allows for calling `Model.paginate` directly from a Mongoose model.