### PR TITLE
Fix getTotalCount()

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -62,7 +62,7 @@ class Pagination {
    * @return {Promise}
    */
   getTotalCount() {
-    const run = () => this.Model.countDocuments(this.criteria);
+    const run = async () => this.Model.countDocuments(this.criteria);
     if (!this.promises.count) {
       this.promises.count = run();
     }


### PR DESCRIPTION
Adding a forgotten `async` in the `getTotalCount` function.